### PR TITLE
Remove dates from non-blogs.

### DIFF
--- a/_layouts/post-date.html
+++ b/_layouts/post-date.html
@@ -20,7 +20,9 @@
             <div class="blog-content">
                 
                 <div class="date-container">
-                    <div class="circle bg-transparent"></div>
+                        <div class="circle"> 
+                        <span><strong>{{ page.date | date: '%B %d, %Y' }}</strong></span>
+                        </div>
                  </div>
                 
                 <!--img src="img/{{ page.img }}" class="img-responsive img-centered" alt="{{ page.alt }}"-->

--- a/_posts/2016-08-11-welcome.markdown
+++ b/_posts/2016-08-11-welcome.markdown
@@ -3,7 +3,7 @@ title: Welcome to AT Labs
 short: Come and have a look at how you can contribute to Auckland Transport with your ideas!
 author: Jan von Bargen
 org: Propellerhead
-layout: post
+layout: post-date
 category: blog
 date: 2016-08-11 17:00:00 +1200
 

--- a/_posts/2016-08-15-change.markdown
+++ b/_posts/2016-08-15-change.markdown
@@ -3,7 +3,7 @@ title: AT is not going to change?
 short: Times are changing - how is Auckland Transport reacting to these challenges
 author: Jan von Bargen
 org: Propellerhead
-layout: post
+layout: post-date
 category: blog
 date: 2016-08-15 11:00:00 +1200
 

--- a/custom.scss
+++ b/custom.scss
@@ -6,6 +6,8 @@
 	color: white;
 }
 
+
+
 .caption{
   font-size: 12px;
 }
@@ -149,4 +151,8 @@
 	.started-section-heading{
 		text-align: left;
 	}
+}
+
+.bg-transparent {
+	background-color: transparent;
 }


### PR DESCRIPTION
A new layout is created called 'post-date'. Any blog (or entries that date make sense) should use it as their layout.
